### PR TITLE
Tutorial: Add a database to the app, use GraphQL to fetch db data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 **/target
 **/gen
 .dep*
+temp.db
 vendor

--- a/db/db.go
+++ b/db/db.go
@@ -1,0 +1,51 @@
+package db
+
+import (
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+)
+
+type User struct {
+	gorm.Model
+	Name     string
+	FavEmoji string
+}
+
+type DBClient struct {
+	db *gorm.DB
+}
+
+func NewClient() (*DBClient, error) {
+	db, err := gorm.Open("sqlite3", "temp.db")
+	if err != nil {
+		return nil, err
+	}
+
+	// Migrate the schema
+	db.AutoMigrate(&User{})
+
+	// put some fake data in our db
+	seedDatabase(db)
+
+	return &DBClient{db}, nil
+}
+
+func (d *DBClient) GetUsers(where ...interface{}) ([]*User, error) {
+	users := []*User{}
+	return users, d.db.Find(&users, where...).Error
+}
+
+func seedDatabase(db *gorm.DB) {
+	// Clear previous db data
+	db.Delete(&User{})
+
+	// Create some fake users
+	db.Create(&User{Name: "Rey", FavEmoji: "100"})
+	db.Create(&User{Name: "BB8", FavEmoji: "fire"})
+	db.Create(&User{Name: "Captain Phasma", FavEmoji: "doughnut"})
+	db.Create(&User{Name: "R2-D2", FavEmoji: "fire"})
+	db.Create(&User{Name: "Leia Organa", FavEmoji: "champagne"})
+	db.Create(&User{Name: "Padmé Amidala", FavEmoji: "cat2"})
+	db.Create(&User{Name: "Enfys Nest", FavEmoji: "dog"})
+	db.Create(&User{Name: "C-3PO", FavEmoji: "pray"})
+}

--- a/emojivoto-web/cmd/server.go
+++ b/emojivoto-web/cmd/server.go
@@ -4,8 +4,10 @@ import (
 	"log"
 	"os"
 
+	"github.com/buoyantio/emojivoto/db"
 	pb "github.com/buoyantio/emojivoto/emojivoto-web/gen/proto"
 	"github.com/buoyantio/emojivoto/emojivoto-web/web"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"google.golang.org/grpc"
 )
 
@@ -31,7 +33,12 @@ func main() {
 	emojiSvcClient := pb.NewEmojiServiceClient(emojiSvcConn)
 	defer emojiSvcConn.Close()
 
-	web.StartServer(webPort, webpackDevServerHost, indexBundle, emojiSvcClient, votingClient)
+	database, err := db.NewClient()
+	if err != nil {
+		panic("failed to connect database")
+	}
+
+	web.StartServer(webPort, webpackDevServerHost, indexBundle, database, emojiSvcClient, votingClient)
 }
 
 func openGrpcClientConnection(host string) *grpc.ClientConn {

--- a/emojivoto-web/web/web.go
+++ b/emojivoto-web/web/web.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/buoyantio/emojivoto/db"
 	pb "github.com/buoyantio/emojivoto/emojivoto-web/gen/proto"
 	"github.com/buoyantio/emojivoto/graphql"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -16,6 +17,7 @@ import (
 )
 
 type WebApp struct {
+	db                  *db.DBClient
 	graphql             *relay.Handler
 	emojiServiceClient  pb.EmojiServiceClient
 	votingServiceClient pb.VotingServiceClient
@@ -394,13 +396,14 @@ func writeError(err error, w http.ResponseWriter, r *http.Request, status int) {
 	json.NewEncoder(w).Encode(errorMessage)
 }
 
-func StartServer(webPort, webpackDevServer, indexBundle string,
+func StartServer(webPort, webpackDevServer, indexBundle string, database *db.DBClient,
 	emojiServiceClient pb.EmojiServiceClient,
 	votingClient pb.VotingServiceClient) {
 
-	schema := graphql.NewGraphQLServer()
+	schema := graphql.NewGraphQLServer(database)
 
 	webApp := &WebApp{
+		db:                  database,
 		graphql:             &relay.Handler{Schema: schema},
 		emojiServiceClient:  emojiServiceClient,
 		votingServiceClient: votingClient,

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -20,6 +20,11 @@ type (
 	helloArgs struct {
 		Name string
 	}
+
+	userResolver struct {
+		Resolver
+		u *db.User
+	}
 )
 
 const Schema = `
@@ -29,11 +34,36 @@ schema {
 
 type Query {
 	hello(name: String!): String!
+	users: [User]!
+}
+
+type User {
+	name: String!
+	favEmoji: String!
 }
 `
 
 func (r *Resolver) Hello(args helloArgs) string {
 	return fmt.Sprintf("Hello %s!", args.Name)
+}
+
+func (r *Resolver) Users() ([]*userResolver, error) {
+	users, err := r.db.GetUsers()
+
+	usersRsp := make([]*userResolver, 0)
+	for _, u := range users {
+		usersRsp = append(usersRsp, &userResolver{*r, u})
+	}
+
+	return usersRsp, err
+}
+
+func (r *userResolver) Name() string {
+	return r.u.Name
+}
+
+func (r *userResolver) FavEmoji() string {
+	return r.u.FavEmoji
 }
 
 func NewGraphQLServer(db *db.DBClient) *graphql.Schema {

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -3,11 +3,14 @@ package graphql
 import (
 	"fmt"
 
+	"github.com/buoyantio/emojivoto/db"
 	graphql "github.com/graph-gophers/graphql-go"
 )
 
 type (
-	Resolver struct{}
+	Resolver struct {
+		db *db.DBClient
+	}
 
 	helloResolver struct {
 		Resolver
@@ -33,6 +36,6 @@ func (r *Resolver) Hello(args helloArgs) string {
 	return fmt.Sprintf("Hello %s!", args.Name)
 }
 
-func NewGraphQLServer() *graphql.Schema {
-	return graphql.MustParseSchema(Schema, &Resolver{})
+func NewGraphQLServer(db *db.DBClient) *graphql.Schema {
+	return graphql.MustParseSchema(Schema, &Resolver{db})
 }


### PR DESCRIPTION
This PR adds a sqlite db to the emojivoto app, and a new graphql query, `users` to fetch all the users.

To get the users data from the db into graphql, we add a new data type, `User`,  and a new query, `users`. We then wire up a resolver to satisfy the `users` query, and a `userResolver` which will return the fields associated with a `User`.

Currently these users aren't related to the emoji, but we'll fix that in the next PR :)

See our list of users in the graphql playground (note that in future PRs we modify the `favEmoji` field, so the following query will only work on this commit :)):
```
{
  users {
    name
    favEmoji
  }
}
```