### PR TITLE
Tutorial: Adding a new GraphQL data type, fetching data from a gRPC service

### DIFF
--- a/emojivoto-web/web/web.go
+++ b/emojivoto-web/web/web.go
@@ -414,7 +414,7 @@ func StartServer(webPort, webpackDevServer, indexBundle string, database *db.DBC
 	emojiServiceClient pb.EmojiServiceClient,
 	votingClient pb.VotingServiceClient) {
 
-	schema := graphql.NewGraphQLServer(database)
+	schema := graphql.NewGraphQLServer(database, emojiServiceClient)
 
 	webApp := &WebApp{
 		db:                  database,


### PR DESCRIPTION
Adds a graphql query and new graphql data type, `Emoji`.

The `Emoji` model is defined in our protobuf file, and we get emojis by making calls to the `emoji` gRPC service.

Adds a resolver which calls the `emoji` gRPC service to get a list of all emoji.
These emojis aren't yet connected to the users in the db, but we'll do that in #7 :)

This query is:
```
query {
  emojis {
    unicode
    shortcode
  }  
}
```