### PR TITLE
Tutorial: Querying - add a query to find emoji by shortcode

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -41,12 +41,12 @@ func seedDatabase(db *gorm.DB) {
 	db.Delete(&User{})
 
 	// Create some fake users
-	db.Create(&User{Name: "Rey", FavEmoji: "100", PublicId: "cGVvcGxlOjg1"})
-	db.Create(&User{Name: "BB8", FavEmoji: "fire", PublicId: "cGVvcGxlOjg3"})
-	db.Create(&User{Name: "Captain Phasma", FavEmoji: "doughnut", PublicId: "cGVvcGxlOjg4"})
+	db.Create(&User{Name: "Rey", FavEmoji: ":100:", PublicId: "cGVvcGxlOjg1"})
+	db.Create(&User{Name: "BB8", FavEmoji: ":fire:", PublicId: "cGVvcGxlOjg3"})
+	db.Create(&User{Name: "Captain Phasma", FavEmoji: ":doughnut:", PublicId: "cGVvcGxlOjg4"})
 	db.Create(&User{Name: "R2-D2", FavEmoji: "fire", PublicId: "cGVvcGxlOjM="})
-	db.Create(&User{Name: "Leia Organa", FavEmoji: "champagne", PublicId: "cGVvcGxlOjU="})
-	db.Create(&User{Name: "Padmé Amidala", FavEmoji: "cat2", PublicId: "cGVvcGxlOjM1"})
-	db.Create(&User{Name: "Jocasta Nu", FavEmoji: "dog", PublicId: "cGVvcGxlOjc0"})
-	db.Create(&User{Name: "C-3PO", FavEmoji: "pray", PublicId: "c3BlY2llczoy"})
+	db.Create(&User{Name: "Leia Organa", FavEmoji: ":champagne:", PublicId: "cGVvcGxlOjU="})
+	db.Create(&User{Name: "Padmé Amidala", FavEmoji: ":cat2:", PublicId: "cGVvcGxlOjM1"})
+	db.Create(&User{Name: "Jocasta Nu", FavEmoji: ":dog:", PublicId: "cGVvcGxlOjc0"})
+	db.Create(&User{Name: "C-3PO", FavEmoji: ":pray:", PublicId: "c3BlY2llczoy"})
 }

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -44,6 +44,7 @@ type Query {
 	hello(name: String!): String!
 	users: [User]!
 	emojis: [Emoji]!
+	emoji(shortcode: String!): Emoji
 }
 
 type User {
@@ -89,6 +90,14 @@ func (r *Resolver) Emojis(ctx context.Context) ([]*emojiResolver, error) {
 	}
 
 	return emojis, err
+}
+
+func (r *Resolver) Emoji(ctx context.Context, args *struct{ Shortcode string }) (*emojiResolver, error) {
+	emojiRsp, err := r.emojiServiceClient.FindByShortcode(ctx, &pb.FindByShortcodeRequest{
+		Shortcode: args.Shortcode,
+	})
+
+	return &emojiResolver{*r, emojiRsp.Emoji}, err
 }
 
 func (r *emojiResolver) Unicode() string {


### PR DESCRIPTION
Adds a new query, `emoji` that allows you to look up an emoji using its shortcode.
This query makes a call to the emoji service using the `FindByShortcode` rpc call.

Example graphql query:
```
query {
  emoji(shortcode:":joy:") {
    unicode
  }  
}
```