### PR TITLE
Tutorial: Connecting data types (connect Users and Emoji)

### DIFF
--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -49,7 +49,7 @@ type Query {
 
 type User {
 	name: String!
-	favEmoji: String!
+	favEmoji: Emoji!
 }
 
 type Emoji {
@@ -77,8 +77,12 @@ func (r *userResolver) Name() string {
 	return r.u.Name
 }
 
-func (r *userResolver) FavEmoji() string {
-	return r.u.FavEmoji
+func (r *userResolver) FavEmoji(ctx context.Context) (*emojiResolver, error) {
+	emojiRsp, err := r.emojiServiceClient.FindByShortcode(ctx, &pb.FindByShortcodeRequest{
+		Shortcode: r.u.FavEmoji,
+	})
+
+	return &emojiResolver{r.Resolver, emojiRsp.Emoji}, err
 }
 
 func (r *Resolver) Emojis(ctx context.Context) ([]*emojiResolver, error) {


### PR DESCRIPTION
Here's where it gets cool! We can connect the data we have for Users to our Emoji data.

In our `users` sql table, we list the user's favourite emoji. We can call the `emoji` grpc service and look up the unicode of the user's favourite emoji, and return that in the response! 

To do this, we modify our `FavEmoji` function (which previously returned the shortcode string) to look up the emoji in the `emoji` service (which conveniently has a `FindByShortcode` endpoint) and return the emoji using an `emojiResolver`.

Now, we can see real emoji when we query users!
```
query {
  users {
    name
    favEmoji {
      unicode
    }
  } 
}
```